### PR TITLE
Count_ways_to_divide_a_circle_by_chords(DP)

### DIFF
--- a/cpp codes/Count_ways_to_divide_a_circle_by_chords(DP)
+++ b/cpp codes/Count_ways_to_divide_a_circle_by_chords(DP)
@@ -1,0 +1,29 @@
+#include<bits/stdc++.h>
+using namespace std;
+
+//The chords are given to be non-intersecting in nature.
+
+int main(){
+    long long int t,n,a,i,j;
+    cin >> t;
+    while(t--){
+        cin >> n;
+        a = 2*n;
+        long long int dp[a+1] = {0};
+        dp[0] = 1;
+        dp[2] = 1;        // only 1 way to divide a circle using 2 points ie. 1 chord 
+        // When 2 points are joined to form a chord, 
+        // two distinct sets on either sides are formed. 
+        // Let points on one side are j, and total is 2*n, 
+        // so points on other side are 2*n-j-2 
+        // (2 ---> the points using which the first chord is formed)
+        for(i=4;i<=a;i+=2){
+        // 2 points are used up each time a chord is formed
+            for(j=0;j<=i-2;j+=2){
+                dp[i] += dp[j]*dp[i-j-2];   
+            }
+        }
+        cout << dp[a] << "\n";
+    }
+    return 0;
+}


### PR DESCRIPTION
t -> no. of testcases
n -> no. of chords to be used
a -> no. of points on the circle used (2*n)

LOGIC -> Two ways are different if there exists a chord which is present in one way and not in other. When 2 points are joined to form a chord, two distinct sets on either side are formed. Let points on one side are j, and total is 2*n, so points on other side are 2*n-j-2 (2 is subtracted because ---> first chord uses 2 points). If we draw a chord from a point in first set to a point in second point, it will surely intersect the chord we’ve just drawn and hence will contradict the non-intersecting nature of chords as given in question.
An alternate way of solving this can be using the formula for finding nth Catalan number (These are a sequence of natural numbers that occur in many interesting counting problems like this one)